### PR TITLE
trigger pass message for events

### DIFF
--- a/janus.go
+++ b/janus.go
@@ -93,6 +93,12 @@ func NewSession_testHelper(id uint64, gw *Gateway) *Session {
 	return newSession(id, gw)
 }
 
+//PassMessage_testHelper so we can trigger certain events for tests
+func PassMessage_testHelper(s *Session, msg interface{}) {
+	passMsg(s.events, msg)
+	return
+}
+
 func newSession(id uint64, gw *Gateway) *Session {
 	session := new(Session)
 	session.id = id


### PR DESCRIPTION
When we have to use the NewSession_testHelper, we have no control over sending messages to the session which we need to do in order to complete the peer connection. This allows us to send the message. I'm not really a huge fan, its definitely not functionality we want in prod but seems necessary for tests. I'm open to other suggestions tho