### PR TITLE
Add RTP Header Extension abs-capture-time to RTP muxer in FFmpeg and send to webrtc receivers

### DIFF
--- a/types.go
+++ b/types.go
@@ -173,10 +173,11 @@ type CreateStreamingMountPointMessage struct {
 // CreateStreamingMountPointMultiStreamMessage ...
 type CreateStreamingMountPointMultiStreamMessage struct {
 	MessageRequest
-	Type    string                  `json:"type"`
-	Id      int                     `json:"id"`
-	RtpSync bool                    `json:"rtp_sync"`
-	Media   []StreamingMediaOptions `json:"media"`
+	Type                    string                  `json:"type"`
+	Id                      int                     `json:"id"`
+	RtpSync                 bool                    `json:"rtp_sync"`
+	AbsCaptureTimeSrcExtID  int                     `json:"abscapturetime_src_ext_id,omitempty"`
+	Media                   []StreamingMediaOptions `json:"media"`
 }
 
 // DestroyStreamingMountPointMessage ...
@@ -185,23 +186,15 @@ type DestroyStreamingMountPointMessage struct {
 	Id int `json:"id"`
 }
 
-// StreamingMediaExtmap represents an RTP header extension mapping for a streaming mountpoint media stream.
-type StreamingMediaExtmap struct {
-	Extmap    int    `json:"extmap"`
-	URI       string `json:"uri"`
-	Direction string `json:"direction,omitempty"`
-}
-
 // StreamingMediaOptions ...
 type StreamingMediaOptions struct {
-	Type     string                 `json:"type"`
-	Mid      string                 `json:"mid"`
-	Label    string                 `json:"label"`
-	Port     int                    `json:"port"`
-	RtcpPort int                    `json:"rtcpport"`
-	Pt       int                    `json:"pt"`
-	RtpMap   string                 `json:"rtpmap"`
-	Extmap   []StreamingMediaExtmap `json:"extmap,omitempty"`
+	Type     string `json:"type"`
+	Mid      string `json:"mid"`
+	Label    string `json:"label"`
+	Port     int    `json:"port"`
+	RtcpPort int    `json:"rtcpport"`
+	Pt       int    `json:"pt"`
+	RtpMap   string `json:"rtpmap"`
 }
 
 // PublishVideoRoomMessage for janus


### PR DESCRIPTION
Janus streaming plugin ignores per-stream extmap in the media array — the
only supported way to enable abs-capture-time is via the top-level
abscapturetime_src_ext_id property on the create request. Moved the setting
from StreamingMediaOptions.Extmap to CreateStreamingMountPointMultiStreamMessage.AbsCaptureTimeSrcExtID
and removed the unused StreamingMediaExtmap type.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- SIBLING_PRS_START -->
## Sibling PRs

- https://github.com/SpalkLtd/janus-go/pull/17
- https://github.com/SpalkLtd/spalk-ffmpeg/pull/93
- https://github.com/SpalkLtd/spalk-live-sync-api/pull/3847
- https://github.com/SpalkLtd/spalk-nginx/pull/643
<!-- SIBLING_PRS_END -->
